### PR TITLE
KAN-32 Chore: Update Gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,11 @@
 plugins {
-    id "java"
+    id "application"
     id "edu.sc.seis.launch4j" version "3.0.6"
 }
 
 group 'org.invaders-sdp'
 version '0.0'
+mainClassName = 'engine.Core'
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
## What
- Update gradle's build target to application instead of java.

Now it can build executable jar, and can use 'run' option to run Invader-SDP application.