### PR TITLE
KAN-36 feat double tab teleport

### DIFF
--- a/src/engine/Cooldown.java
+++ b/src/engine/Cooldown.java
@@ -24,7 +24,7 @@ public class Cooldown {
 	 * @param milliseconds
 	 *            Time until cooldown period is finished.
 	 */
-	protected Cooldown(final int milliseconds) {
+	public Cooldown(final int milliseconds) {
 		this.milliseconds = milliseconds;
 		this.variance = 0;
 		this.duration = milliseconds;
@@ -45,6 +45,16 @@ public class Cooldown {
 		this.variance = variance;
 		this.time = 0;
 	}
+
+	public int getRemainingTime() {
+		long currentTime = System.currentTimeMillis();
+		long elapsedTime = currentTime - this.time;
+
+		if (elapsedTime >= this.duration) { return 0; }
+		return (int) (this.duration - elapsedTime);
+	}
+
+	public int getTotalDuration() { return this.duration; }
 
 	/**
 	 * Checks if the cooldown is finished.

--- a/src/engine/DrawManagerImpl.java
+++ b/src/engine/DrawManagerImpl.java
@@ -218,17 +218,24 @@ public class DrawManagerImpl extends DrawManager {
         backBufferGraphics.drawString(playerDistanceString, xPosition, yPosition);
     }
 
-    public static void drawCooldownCircle(Screen screen, final int centerX, final int centerY, float percentage) {
+    public static void drawCooldownCircle(Screen screen, final int centerX, final int centerY, float percentage, int remainingSeconds) {
         int radius = 20;
         int angle = (int) (360 * percentage);
 
-        backBufferGraphics.setColor(Color.BLACK);
-        backBufferGraphics.fillArc(centerX - radius, centerY - radius, 2 * radius, 2 * radius, 90, -360);
         backBufferGraphics.setColor(Color.GREEN);
-        backBufferGraphics.fillArc(centerX-radius, centerY-radius, 2 * radius, 2 * radius, 90, -angle);
+        backBufferGraphics.fillArc(centerX - radius, 0, 2 * radius, 2 * radius, 90, -360);
+        backBufferGraphics.setColor(Color.BLACK);
+        backBufferGraphics.fillArc(centerX-radius, 0, 2 * radius, 2 * radius, 90, -angle);
         backBufferGraphics.setColor(Color.WHITE);
-        backBufferGraphics.drawArc(centerX - radius, centerY - radius, 2 * radius, 2 * radius, 90, -360);
+        backBufferGraphics.drawArc(centerX - radius, 0, 2 * radius, 2 * radius, 90, -360);
         backBufferGraphics.setFont(fontRegular);
+        String timeText = String.valueOf(remainingSeconds/1000);
+        backBufferGraphics.setFont(fontRegular);
+        int textWidth = fontRegularMetrics.stringWidth(timeText);
+        backBufferGraphics.drawString(timeText, centerX - textWidth / 2, 25);
+
+        String cooldownLabel = "Cooldown: ";
+        backBufferGraphics.drawString(cooldownLabel,centerX - radius - fontRegularMetrics.stringWidth(cooldownLabel) - 10, 25);
     }
 
     /**

--- a/src/engine/DrawManagerImpl.java
+++ b/src/engine/DrawManagerImpl.java
@@ -218,6 +218,19 @@ public class DrawManagerImpl extends DrawManager {
         backBufferGraphics.drawString(playerDistanceString, xPosition, yPosition);
     }
 
+    public static void drawCooldownCircle(Screen screen, final int centerX, final int centerY, float percentage) {
+        int radius = 20;
+        int angle = (int) (360 * percentage);
+
+        backBufferGraphics.setColor(Color.BLACK);
+        backBufferGraphics.fillArc(centerX - radius, centerY - radius, 2 * radius, 2 * radius, 90, -360);
+        backBufferGraphics.setColor(Color.GREEN);
+        backBufferGraphics.fillArc(centerX-radius, centerY-radius, 2 * radius, 2 * radius, 90, -angle);
+        backBufferGraphics.setColor(Color.WHITE);
+        backBufferGraphics.drawArc(centerX - radius, centerY - radius, 2 * radius, 2 * radius, 90, -360);
+        backBufferGraphics.setFont(fontRegular);
+    }
+
     /**
      * Draws 2P's bulletSpeed on screen.
      *

--- a/src/engine/InputManager.java
+++ b/src/engine/InputManager.java
@@ -2,6 +2,8 @@ package engine;
 
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Manages keyboard input for the provided screen.
@@ -17,6 +19,12 @@ public final class InputManager implements KeyListener {
 	private static boolean[] keys;
 	/** Singleton instance of the class. */
 	private static InputManager instance;
+
+	/**
+	 * The threshold time (in milliseconds) to detect a double-tap event
+	 */
+	private Map<Integer, Long> lastKeyPress = new HashMap<>();
+	private static final int DOUBLE_TAP_THRESHOLD = 300;
 
 	/**
 	 * Private constructor.
@@ -69,6 +77,20 @@ public final class InputManager implements KeyListener {
 	public void keyReleased(final KeyEvent key) {
 		if (key.getKeyCode() >= 0 && key.getKeyCode() < NUM_KEYS)
 			keys[key.getKeyCode()] = false;
+	}
+
+	/**
+	 * Checks if a given key code has been double-tapped within the defined threshold.
+	 *
+	 * @param keyCode The key code to check for a double-tap.
+	 * @return True if the key was double-tapped, false otherwise.
+	 */
+	public boolean isDoubleTap(int keyCode) {
+		long currentTime = System.currentTimeMillis();
+		long lastPressTime = lastKeyPress.getOrDefault(keyCode, 0L);
+		boolean isDoubleTap = (currentTime - lastPressTime) <= DOUBLE_TAP_THRESHOLD;
+		lastKeyPress.put(keyCode, currentTime);
+		return isDoubleTap;
 	}
 
 	/**

--- a/src/engine/InputManager.java
+++ b/src/engine/InputManager.java
@@ -17,13 +17,6 @@ public final class InputManager implements KeyListener {
 	private static boolean[] keys;
 	/** Singleton instance of the class. */
 	private static InputManager instance;
-
-	private long lastRightTapTime = 0;
-	private long lastLeftTapTime = 0;
-	private boolean isRightKeyReleased = true;
-	private boolean isLeftKeyReleased = true;
-	private long isRightKeyPressed = 0;
-	private long isLeftKeyPressed = 0;
 	/**
 	 * Private constructor.
 	 */
@@ -62,8 +55,6 @@ public final class InputManager implements KeyListener {
 	@Override
 	public void keyPressed(final KeyEvent key) {
 		if (key.getKeyCode() >= 0 && key.getKeyCode() < NUM_KEYS) { keys[key.getKeyCode()] = true; }
-		if (key.getKeyCode() == KeyEvent.VK_RIGHT) { isRightKeyPressed = System.currentTimeMillis(); }
-		if (key.getKeyCode() == KeyEvent.VK_LEFT) { isLeftKeyPressed = System.currentTimeMillis(); }
 	}
 
 	/**
@@ -75,34 +66,6 @@ public final class InputManager implements KeyListener {
 	@Override
 	public void keyReleased(final KeyEvent key) {
 		if (key.getKeyCode() >= 0 && key.getKeyCode() < NUM_KEYS) { keys[key.getKeyCode()] = false; }
-		if (key.getKeyCode() == KeyEvent.VK_RIGHT) { isRightKeyReleased = true; }
-		if (key.getKeyCode() == KeyEvent.VK_LEFT) { isLeftKeyReleased = true; }
-	}
-
-	public boolean isDoubleTab(int keyCode) {
-		long currentTime = System.currentTimeMillis();
-
-		if (keyCode == KeyEvent.VK_RIGHT) {
-			if (!isRightKeyReleased || currentTime - isRightKeyPressed > 500) { return false; }
-			isRightKeyReleased = false;
-			if(currentTime - lastRightTapTime < 500) {
-				lastRightTapTime = 0;
-				isRightKeyReleased = true;
-				return true;
-			}
-			lastRightTapTime = currentTime;
-		}
-		if (keyCode == KeyEvent.VK_LEFT) {
-			if (!isLeftKeyReleased || currentTime - isLeftKeyPressed > 500) { return false; }
-			isLeftKeyReleased = false;
-			if(currentTime - lastLeftTapTime < 500) {
-				lastLeftTapTime = 0;
-				isLeftKeyReleased = true;
-				return true;
-			}
-			lastLeftTapTime = currentTime;
-		}
-		return false;
 	}
 
 	/**

--- a/src/entity/Ship.java
+++ b/src/entity/Ship.java
@@ -11,8 +11,7 @@ import java.awt.event.KeyEvent;
 import java.io.IOException;
 import java.util.Set;
 
-import static engine.Globals.barrier_DURATION;
-import static engine.Globals.getLogger;
+import static engine.Globals.*;
 
 class PlayerGrowth {
 
@@ -144,7 +143,6 @@ public class Ship extends Entity {
 	@Getter @Setter
 	private long barrierActivationTime;
 
-
 	//TODO : Move health to ship from GameScreen, and Add immunity time
 
 	/**
@@ -224,7 +222,7 @@ public class Ship extends Entity {
 
 			if(isBombBullet()) {
 				BombBullet bombBullet = new BombBullet(positionX, positionY, growth.getBulletSpeed());
-				Globals.getCurrentScreen().addEntity(bombBullet);
+				getCurrentScreen().addEntity(bombBullet);
 				this.setBombBullet(false);
 			}
 			else{
@@ -256,9 +254,9 @@ public class Ship extends Entity {
 			this.setEnabled(false);
 		}
 
-		GameScreen screen = (GameScreen) Globals.getCurrentScreen();
+		GameScreen screen = (GameScreen) getCurrentScreen();
 		if (!isDestroyed() && this.canMove) {
-			InputManager inputManager = Globals.getInputManager();
+			InputManager inputManager = getInputManager();
 
 			boolean moveRight = inputManager.isKeyDown(KEY_RIGHT);
 			boolean moveLeft = inputManager.isKeyDown(KEY_LEFT);
@@ -276,11 +274,11 @@ public class Ship extends Entity {
 
 			 if (moveRight && !isRightBorder) {
 				this.moveRight();
-				screen.backgroundMoveRight = true;
+				screen.backgroundMoveRight = false;
 			}
 			if (moveLeft && !isLeftBorder) {
 				this.moveLeft();
-				screen.backgroundMoveLeft = true;
+				screen.backgroundMoveLeft = false;
 			}
 			if (moveUp && !isTopBorder) {
 				this.moveUP();
@@ -292,7 +290,7 @@ public class Ship extends Entity {
 				if (this.shoot()) {
 					screen.bulletsShot++;
 					screen.fire_id++;
-					Globals.getLogger().fine("Bullet's fire_id is " + screen.fire_id);
+					getLogger().fine("Bullet's fire_id is " + screen.fire_id);
 				}
 		}
 
@@ -385,7 +383,7 @@ public class Ship extends Entity {
 	public void subtractHealth(){
 		this.playDestroyAnimation();
 		this.health -= 1;
-		Globals.getLogger().info("Hit on player ship, " + this.health
+		getLogger().info("Hit on player ship, " + this.health
 				+ " lives remaining.");
 
 		// Sound Operator
@@ -397,26 +395,22 @@ public class Ship extends Entity {
 	//barrier item stuffs
 	public void updateBarrier() {
 		if (this.barrierActive) {
-			this.setSpriteType(DrawManager.SpriteType.ShipBarrierStatus);
+			this.setSpriteType(SpriteType.ShipBarrierStatus);
 
 			long currentTime = System.currentTimeMillis();
 
 			if (currentTime - this.barrierActivationTime >= barrier_DURATION) {
-				this.setSpriteType(DrawManager.SpriteType.Ship);
+				this.setSpriteType(SpriteType.Ship);
 				deactivatebarrier();    // deactive barrier
 			}
 		}
 	}
 
-	public void detectedDoubleTab(boolean isDoubleTabRight, boolean isDoubleTabLeft, int screenWidth) {
-		if (isDoubleTabRight) {
-			getLogger().info("Detected double tab");
-			this.setPosition(screenWidth - this.getWidth(), this.getPositionY());
-		}
-		else if (isDoubleTabLeft) {
-			getLogger().info("Detected double tab");
-			this.setPosition(0, this.getPositionY());
-		}
+	public void moveToEdgeLeft(boolean isLeft) {
+			if (isLeft) { this.positionX = getCurrentScreen().getWidth()-this.width; }
+	}
+	public void moveToEdgeRight(boolean isRight) {
+			if (isRight) { this.positionX = 0; }
 	}
 
 	public void activatebarrier() {
@@ -426,6 +420,6 @@ public class Ship extends Entity {
 
 	public void deactivatebarrier() {
 		this.barrierActive = false;
-		Globals.getLogger().info("barrier effect ends");
+		getLogger().info("barrier effect ends");
 	}
 }

--- a/src/entity/Ship.java
+++ b/src/entity/Ship.java
@@ -1,19 +1,18 @@
 package entity;
 
-import java.awt.Color;
-import java.awt.event.KeyEvent;
-import java.io.IOException;
-import java.util.Set;
-
 import engine.*;
 import engine.DrawManager.SpriteType;
-// Import NumberOfBullet class
-// Import ShipStatus class
 import lombok.Getter;
 import lombok.Setter;
 import screen.GameScreen;
 
+import java.awt.*;
+import java.awt.event.KeyEvent;
+import java.io.IOException;
+import java.util.Set;
+
 import static engine.Globals.barrier_DURATION;
+import static engine.Globals.getLogger;
 
 class PlayerGrowth {
 
@@ -250,7 +249,6 @@ public class Ship extends Entity {
 	 */
 	@Override
 	public final void update() {
-		//Update sprite type based on destruction state
 		this.spriteType = this.destructionCooldown.checkFinished() ? SpriteType.Ship : SpriteType.ShipDestroyed;
 
 		if(!isPlayDestroyAnimation() && isDestroyed()){
@@ -276,17 +274,7 @@ public class Ship extends Entity {
 			boolean isBottomBorder = getPositionY() + this.getHeight() + this.getSpeed()
 					> screen.getHeight() - 63;
 
-			if (inputManager.isDoubleTap(KEY_RIGHT) && !isRightBorder) {
-				this.positionX = screen.getWidth() - this.getWidth();
-				Globals.getLogger().info("Double Tap detected! Ship teleported to the right edge.");
-			}
-
-			if (inputManager.isDoubleTap(KEY_LEFT) && !isLeftBorder) {
-				this.positionX = 0;
-				Globals.getLogger().info("Double Tap detected! Ship teleported to the left edge.");
-			}
-
-			if (moveRight && !isRightBorder) {
+			 if (moveRight && !isRightBorder) {
 				this.moveRight();
 				screen.backgroundMoveRight = true;
 			}
@@ -417,6 +405,17 @@ public class Ship extends Entity {
 				this.setSpriteType(DrawManager.SpriteType.Ship);
 				deactivatebarrier();    // deactive barrier
 			}
+		}
+	}
+
+	public void detectedDoubleTab(boolean isDoubleTabRight, boolean isDoubleTabLeft, int screenWidth) {
+		if (isDoubleTabRight) {
+			getLogger().info("Detected double tab");
+			this.setPosition(screenWidth - this.getWidth(), this.getPositionY());
+		}
+		else if (isDoubleTabLeft) {
+			getLogger().info("Detected double tab");
+			this.setPosition(0, this.getPositionY());
 		}
 	}
 

--- a/src/entity/Ship.java
+++ b/src/entity/Ship.java
@@ -250,10 +250,8 @@ public class Ship extends Entity {
 	 */
 	@Override
 	public final void update() {
-		if (!this.destructionCooldown.checkFinished())
-			this.spriteType = SpriteType.ShipDestroyed;
-		else
-			this.spriteType = SpriteType.Ship;
+		//Update sprite type based on destruction state
+		this.spriteType = this.destructionCooldown.checkFinished() ? SpriteType.Ship : SpriteType.ShipDestroyed;
 
 		if(!isPlayDestroyAnimation() && isDestroyed()){
 			// Do not draw when ship destroyed
@@ -277,6 +275,16 @@ public class Ship extends Entity {
                     < screen.getHeight() * 0.6;
 			boolean isBottomBorder = getPositionY() + this.getHeight() + this.getSpeed()
 					> screen.getHeight() - 63;
+
+			if (inputManager.isKeyDown(KEY_RIGHT) && !isRightBorder) {
+				this.positionX = screen.getWidth() - this.getWidth();
+				Globals.getLogger().info("Double Tap detected! Ship teleported to the right edge.");
+			}
+
+			if (inputManager.isKeyDown(KEY_LEFT) && !isLeftBorder) {
+				this.positionX = 0;
+				Globals.getLogger().info("Double Tap detected! Ship teleported to the left edge.");
+			}
 
 			if (moveRight && !isRightBorder) {
 				this.moveRight();

--- a/src/entity/Ship.java
+++ b/src/entity/Ship.java
@@ -416,15 +416,21 @@ public class Ship extends Entity {
 	}
 
 	public void detectedDoubleTap(){
-		if (Globals.getInputManager().isDoubleTab(KeyEvent.VK_RIGHT) && doubleTapCooldown.getRemainingTime() == 0 ) {
-			moveToEdgeLeft(true);
-			Globals.getLogger().info("Detected Double Tab Right");
-			doubleTapCooldown.reset();
-		}
-		if (Globals.getInputManager().isDoubleTab(KeyEvent.VK_LEFT) && doubleTapCooldown.getRemainingTime() == 0) {
-			moveToEdgeRight(true);
-			Globals.getLogger().info("Detected Double Tab Left");
-			doubleTapCooldown.reset();
+		InputManager inputManager = Globals.getInputManager();
+
+		boolean currentKeyPressed = !(inputManager.isKeyDown(KEY_UP) || inputManager.isKeyDown(KEY_DOWN)
+									|| inputManager.isKeyDown(KEY_LEFT) || inputManager.isKeyDown(KEY_RIGHT));
+		if (currentKeyPressed) {
+			if (Globals.getInputManager().isDoubleTab(KeyEvent.VK_RIGHT) && doubleTapCooldown.getRemainingTime() == 0) {
+				moveToEdgeLeft(true);
+				Globals.getLogger().info("Detected Double Tab Right");
+				doubleTapCooldown.reset();
+			}
+			if (Globals.getInputManager().isDoubleTab(KeyEvent.VK_LEFT) && doubleTapCooldown.getRemainingTime() == 0) {
+				moveToEdgeRight(true);
+				Globals.getLogger().info("Detected Double Tab Left");
+				doubleTapCooldown.reset();
+			}
 		}
 	}
 	public void activatebarrier() {

--- a/src/entity/Ship.java
+++ b/src/entity/Ship.java
@@ -142,6 +142,8 @@ public class Ship extends Entity {
 	/**	Store barrier acivated time */
 	@Getter @Setter
 	private long barrierActivationTime;
+	@Getter
+	private Cooldown doubleTapCooldown = new Cooldown(3500);
 
 	//TODO : Move health to ship from GameScreen, and Add immunity time
 
@@ -413,6 +415,18 @@ public class Ship extends Entity {
 			if (isRight) { this.positionX = 0; }
 	}
 
+	public void detectedDoubleTap(){
+		if (Globals.getInputManager().isDoubleTab(KeyEvent.VK_RIGHT) && doubleTapCooldown.getRemainingTime() == 0 ) {
+			moveToEdgeLeft(true);
+			Globals.getLogger().info("Detected Double Tab Right");
+			doubleTapCooldown.reset();
+		}
+		if (Globals.getInputManager().isDoubleTab(KeyEvent.VK_LEFT) && doubleTapCooldown.getRemainingTime() == 0) {
+			moveToEdgeRight(true);
+			Globals.getLogger().info("Detected Double Tab Left");
+			doubleTapCooldown.reset();
+		}
+	}
 	public void activatebarrier() {
 		this.barrierActive = true;
 		this.barrierActivationTime = System.currentTimeMillis();

--- a/src/entity/Ship.java
+++ b/src/entity/Ship.java
@@ -272,16 +272,16 @@ public class Ship extends Entity {
 			boolean isLeftBorder = getPositionX()
 					- this.getSpeed() < 1;
 			boolean isTopBorder = (getPositionY() - this.getSpeed())
-                    < screen.getHeight() * 0.6;
+					< screen.getHeight() * 0.6;
 			boolean isBottomBorder = getPositionY() + this.getHeight() + this.getSpeed()
 					> screen.getHeight() - 63;
 
-			if (inputManager.isKeyDown(KEY_RIGHT) && !isRightBorder) {
+			if (inputManager.isDoubleTap(KEY_RIGHT) && !isRightBorder) {
 				this.positionX = screen.getWidth() - this.getWidth();
 				Globals.getLogger().info("Double Tap detected! Ship teleported to the right edge.");
 			}
 
-			if (inputManager.isKeyDown(KEY_LEFT) && !isLeftBorder) {
+			if (inputManager.isDoubleTap(KEY_LEFT) && !isLeftBorder) {
 				this.positionX = 0;
 				Globals.getLogger().info("Double Tap detected! Ship teleported to the left edge.");
 			}
@@ -379,7 +379,7 @@ public class Ship extends Entity {
 	public final double getSpeed() {
 		return growth.getMoveSpeed();
 	}
-	
+
 	/**
 	 * Calculates and returns the bullet speed in Pixels per frame.
 	 *

--- a/src/screen/GameScreen.java
+++ b/src/screen/GameScreen.java
@@ -82,8 +82,6 @@ public class GameScreen extends Screen {
     public boolean backgroundMoveLeft = false;
 	public boolean backgroundMoveRight = false;
 
-	private Cooldown doubleTapCooldown = new Cooldown(3500);
-
 	// --- OBSTACLES
 	private Cooldown obstacleSpawnCooldown; //control obstacle spawn speed
 
@@ -242,17 +240,7 @@ public class GameScreen extends Screen {
 		super.update();
 
 		if (gameProgress) {
-			if (Globals.getInputManager().isDoubleTab(KeyEvent.VK_RIGHT) && doubleTapCooldown.getRemainingTime() == 0 ) {
-				ship1.moveToEdgeLeft(true);
-				Globals.getLogger().info("Detected Double Tab Right");
-				doubleTapCooldown.reset();
-			}
-			if (Globals.getInputManager().isDoubleTab(KeyEvent.VK_LEFT) && doubleTapCooldown.getRemainingTime() == 0) {
-				ship1.moveToEdgeRight(true);
-				Globals.getLogger().info("Detected Double Tab Left");
-				doubleTapCooldown.reset();
-			}
-
+			ship1.detectedDoubleTap();
 			// --- OBSTACLES
 			if (this.obstacleSpawnCooldown.checkFinished()) {
 				// Adjust spawn amount based on the level
@@ -294,7 +282,6 @@ public class GameScreen extends Screen {
 			this.enemyShipFormation.update();
 			this.enemyShipFormation.shoot();
 			updatePlayerDistance();
-			drawManagerImpl.drawPlayerDistance(this, getPlayerDistance());
 
 			int currentRemainingEnemies = getRemainingEnemies();
 			int destroyedEnemies = previousRemainingEnemies - currentRemainingEnemies;
@@ -386,10 +373,10 @@ public class GameScreen extends Screen {
 	 * Draws the elements associated with the screen.
 	 */
 	public void draw() {
-		float cooldownPercentage = doubleTapCooldown.getTotalDuration() > 0
-				? (float) doubleTapCooldown.getRemainingTime() / doubleTapCooldown.getTotalDuration()
+		float cooldownPercentage = ship1.getDoubleTapCooldown().getTotalDuration() > 0
+				? (float) ship1.getDoubleTapCooldown().getRemainingTime() / ship1.getDoubleTapCooldown().getTotalDuration()
 				: 0;
-		int remainingSeconds = (int)Math.ceil((float) doubleTapCooldown.getRemainingTime());
+		int remainingSeconds = (int)Math.ceil((float) ship1.getDoubleTapCooldown().getRemainingTime());
 		/** ### TEAM INTERNATIONAL ### */
 		drawManager.drawBackground(backgroundMoveRight, backgroundMoveLeft);
 		this.backgroundMoveRight = false;
@@ -416,7 +403,7 @@ public class GameScreen extends Screen {
 		// Call the method in DrawManagerImpl - Soomin Lee / TeamHUD
 		drawManager.drawItem(this); // HUD team - Jo Minseo
 		DrawManagerImpl.drawCooldownCircle(this, this.getWidth() - 30, 60, cooldownPercentage, remainingSeconds);
-
+		drawManagerImpl.drawPlayerDistance(this, getPlayerDistance());
 
 
 		// Countdown to game start.

--- a/src/screen/GameScreen.java
+++ b/src/screen/GameScreen.java
@@ -240,7 +240,6 @@ public class GameScreen extends Screen {
 		super.update();
 
 		if (gameProgress) {
-			ship1.detectedDoubleTap();
 			// --- OBSTACLES
 			if (this.obstacleSpawnCooldown.checkFinished()) {
 				// Adjust spawn amount based on the level

--- a/src/screen/GameScreen.java
+++ b/src/screen/GameScreen.java
@@ -238,10 +238,15 @@ public class GameScreen extends Screen {
 	protected boolean update() {
 		boolean gameProgress = inputDelay.checkFinished() && !isLevelFinished();
 		ship1.setCanMove(gameProgress && ship1.getHealth() > 0 && ship1.getDestructionCooldown().checkFinished());
+		InputManager inputManager = Globals.getInputManager();
 
 		super.update();
 
 		if (gameProgress) {
+			boolean isDoubleTapRight = inputManager.isDoubleTab(KeyEvent.VK_RIGHT);
+			boolean isDoubleTapLeft = inputManager.isDoubleTab(KeyEvent.VK_LEFT);
+
+			ship1.detectedDoubleTab(isDoubleTapRight, isDoubleTapLeft, this.width);
 			// --- OBSTACLES
 			if (this.obstacleSpawnCooldown.checkFinished()) {
 				// Adjust spawn amount based on the level

--- a/src/screen/GameScreen.java
+++ b/src/screen/GameScreen.java
@@ -82,7 +82,7 @@ public class GameScreen extends Screen {
     public boolean backgroundMoveLeft = false;
 	public boolean backgroundMoveRight = false;
 
-	private Cooldown doubleTapCooldown = new Cooldown(3000);
+	private Cooldown doubleTapCooldown = new Cooldown(3500);
 
 	// --- OBSTACLES
 	private Cooldown obstacleSpawnCooldown; //control obstacle spawn speed
@@ -389,6 +389,7 @@ public class GameScreen extends Screen {
 		float cooldownPercentage = doubleTapCooldown.getTotalDuration() > 0
 				? (float) doubleTapCooldown.getRemainingTime() / doubleTapCooldown.getTotalDuration()
 				: 0;
+		int remainingSeconds = (int)Math.ceil((float) doubleTapCooldown.getRemainingTime());
 		/** ### TEAM INTERNATIONAL ### */
 		drawManager.drawBackground(backgroundMoveRight, backgroundMoveLeft);
 		this.backgroundMoveRight = false;
@@ -414,7 +415,7 @@ public class GameScreen extends Screen {
 		DrawManagerImpl.drawTime(this, this.playTime);
 		// Call the method in DrawManagerImpl - Soomin Lee / TeamHUD
 		drawManager.drawItem(this); // HUD team - Jo Minseo
-		DrawManagerImpl.drawCooldownCircle(this, this.getWidth() - 30, 60, cooldownPercentage);
+		DrawManagerImpl.drawCooldownCircle(this, this.getWidth() - 30, 60, cooldownPercentage, remainingSeconds);
 
 
 


### PR DESCRIPTION
## What  
This PR adds enhancements and fixes related to the teleportation feature and cooldown display. It includes the following changes:  
- **Handled Key Holding:** Implemented an exception to ensure teleportation does not trigger while holding down a key.  
- **Teleport Cooldown:** Adjusted the teleportation cooldown time to 3.5 seconds.  
- **Cooldown Display:** Added a visual representation of the cooldown on the screen, including a countdown timer inside a circular indicator.  
- **Double-Tap Teleportation:** Enabled teleportation to the edges of the screen when double-tapping the respective direction keys.  
- **Distance Calculation:** Distance calculation is currently non-functional and will be addressed in a future update.  

## Why  
The teleportation feature required fine-tuning to improve usability and visual feedback. These changes ensure a smoother and more user-friendly experience, while avoiding unintended behavior such as triggering actions while holding down keys.  

## How to Test  
1. **Test Key Holding Exception:**  
   - Press and hold the right or left directional key and ensure that teleportation is not triggered.  

2. **Test Cooldown Display:**  
   - Perform a double-tap teleportation.  
   - Verify that a cooldown circle with a countdown timer appears on the screen, preventing immediate reuse of the teleport feature.  

3. **Test Cooldown Timing:**  
   - Wait for 3.5 seconds after teleportation and ensure that the feature becomes available again.  

4. **Test Edge Teleportation:**  
   - Double-tap the left key and confirm the player teleports to the left edge of the screen.  
   - Double-tap the right key and confirm the player teleports to the right edge of the screen.  

5. **Test Distance Calculation:**  
   - Attempt to calculate the distance moved by the player. Note that this feature is currently non-functional.  
