### PR TITLE
KAN-54/Chore:Add test step at build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,18 @@ jobs:
     - name: Build with Gradle
       run: ./gradlew createExe
 
-    - uses: actions/upload-artifact@v4
+    - name: Upload test report artifact
+      if: failure()
+      uses: actions/upload-artifact@v4
+      id: upload_unsigned_v4
+      with:
+        name: Test-Report
+        path: build/reports/tests/test
+      continue-on-error: true
+
+    - name: Upload build artifact
+      if: success()
+      uses: actions/upload-artifact@v4
       id: upload_unsigned_v4
       with:
         name: Invaders-SDP

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,9 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
 
+    - name: Test with Gradle
+      run: ./gradlew test
+
     - name: Build with Gradle
       run: ./gradlew createExe
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Upload test report artifact
       if: failure()
       uses: actions/upload-artifact@v4
-      id: upload_unsigned_v4
+      id: upload_report_v4
       with:
         name: Test-Report
         path: build/reports/tests/test


### PR DESCRIPTION
## What
This PR add test step at build workflow
- Add test step before build
- Upload report when test step is failed

Current build workflow will failed on test step because there is error when loading mp3 file. this will be handled on #26 